### PR TITLE
domd: Work around base_set_conf_value setting empty var

### DIFF
--- a/recipes-domd/agl/inc/domd-agl-image.inc
+++ b/recipes-domd/agl/inc/domd-agl-image.inc
@@ -89,7 +89,7 @@ configure_versions_rcar() {
     fi
 
     # Disable shared link for GO packages
-    base_set_conf_value ${local_conf} GO_LINKSHARED ""
+    base_set_conf_value ${local_conf} GO_LINKSHARED " "
 
     # FIXME: normally bitbake fails with error if there are bbappends w/o recipes
     # which is the case for agl-demo-platform's recipe-platform while building


### PR DESCRIPTION
base_set_conf_value produces wrong result if the value to be set
is an empty line, e.g. "". Work this around by providing a
space in the quotes.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>