### PR TITLE
domd/agl: Remove dhcp-{client|server} from the build

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -20,7 +20,6 @@ IMAGE_INSTALL_append = " \
     nftables \
     ntpdate-systemd \
     tzdata \
-    dhcp-client \
     xen-base \
     xen-flask \
     xen-xenstat \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -39,14 +39,3 @@ populate_vmlinux () {
 }
 
 IMAGE_POSTPROCESS_COMMAND += "populate_vmlinux; "
-
-remove_dns () {
-    rm -rf ${IMAGE_ROOTFS}/lib/systemd/system/named.service
-    rm -rf ${IMAGE_ROOTFS}/etc/default/bind9
-    rm -rf ${IMAGE_ROOTFS}/etc/bind
-    rm -rf ${IMAGE_ROOTFS}/usr/bin/bind9-config
-    rm -rf ${IMAGE_ROOTFS}/usr/sbin/named
-}
-
-ROOTFS_POSTPROCESS_COMMAND += "remove_dns; "
-

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-core-connectivity.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-core-connectivity.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN}_remove = "dhcp-server"

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-demo.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-demo.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN}_remove = "dhcp-client"


### PR DESCRIPTION
We do not need dhcp-{client|server} because we already have
connmand/dnsmasq services on the system. This also solves
the problem that dhcp-{client|server} have a runtime dependency
on bind service which interferes with dnsmasq at least.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>