### PR TITLE
domf: add update ca certificates into first boot script

### DIFF
--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/files/first_boot.sh
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/files/first_boot.sh
@@ -8,5 +8,11 @@ echo "Enable disk quotas"
 
 quotacheck -avum && quotaon -avu
 
+# Update certificates
+
+echo "Update certificates"
+
+update-ca-certificates
+
 # Disable first boot service
 systemctl disable first_boot.service


### PR DESCRIPTION
It is required to use aos/rootCA.crt

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>