### PR TITLE
domu: Remove non-existent files from SRC_URI

### DIFF
--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/systemd/systemd_%.bbappend
@@ -1,9 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = " \
-    file://ip_forward.conf \
-"
-
 PACKAGECONFIG_append = " networkd"
 PACKAGECONFIG_append = " iptc"
 PACKAGECONFIG_append = " resolved"


### PR DESCRIPTION
A file from SRC_URI was removed from files, but still referenced
by the recipe. Fix this by removing the reference.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>