### PR TITLE
domd: Make dnsmasq service require systemd-resolved

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/files/depend.conf
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/files/depend.conf
@@ -1,4 +1,4 @@
 [Unit]
 Wants=network-online.target
 After=network-online.target
-After=systemd-resolved.service
+Requires=systemd-resolved.service


### PR DESCRIPTION
Currently dnsmasq service is configured to run right after
systemd-resolved services, but the intention was it runs after
resolved has successfully started, not only ran.
Fix this by requiring systemd-resolved to start before
starting dnsmasq service.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>