### PR TITLE
domf: Fix openssh-sshd dependency

### DIFF
--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
@@ -1,7 +1,7 @@
 IMAGE_INSTALL_append = " \
     tzdata \
     aos-servicemanager \
-    openssg-sshd \
+    openssh-sshd \
     openssh-scp \
 "
 


### PR DESCRIPTION
openssh-sshd' package name was misspelled while adding to the image.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Reported-by: Iurii Artemenko <iurii_artemenko@epam.com>