### PR TITLE
xen: Fix fetcher failure while working with tags

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -5,5 +5,7 @@
 ################################################################################
 require ../meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https"
+# N.B. - nobranch: Don't check the SHA validation for branch. set this option
+# for the recipe referring to commit which is valid in tag instead of branch.
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;nobranch=1"
 SRCREV = "RELEASE-4.10.0-xt0.6.final"


### PR DESCRIPTION
Use "nobranch" in SRC_URI as we are referring to a commit in a tag,
not branch. And bitbake by default assumes branch=master, which makes the
fetcher fail:
ERROR: xen-4.10.0+gitAUTOINC+7b337a7c97-r0 do_fetch: Fetcher failure: Unable to find revision 7b337a7c97c80bc4637d9e8c97002218d5b05e61 in branch master even from upstream
ERROR: xen-4.10.0+gitAUTOINC+7b337a7c97-r0 do_fetch: Fetcher failure for URL: 'git://github.com/xen-troops/xen.git;protocol=https'. Unable to fetch URL from any source.
ERROR: xen-4.10.0+gitAUTOINC+7b337a7c97-r0 do_fetch: Function failed: base_do_fetch

Fix this by providing "nobranch=1": "don't check the SHA validation for branch.
Set this option for the recipe referring to commit which is valid in tag
instead of branch."

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>