### PR TITLE
domd, domf: enable logrotate

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -5,6 +5,7 @@ IMAGE_INSTALL_append = " \
     kmscube \
     aos-vis \
     ${@bb.utils.contains('AOS_VIS_PLUGINS', 'telemetryemulatoradapter', 'telemetry-emulator', '', d)} \
+    logrotate \
 "
 
 #Add Xen and additional packages to build

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/files/messages
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/files/messages
@@ -1,0 +1,6 @@
+/var/log/messages {
+    size 8M
+    missingok
+    rotate 1
+    notifempty
+}

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/files/xen
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/files/xen
@@ -1,0 +1,6 @@
+/var/log/xen/* {
+    size 2M
+    missingok
+    rotate 1
+    notifempty
+}

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/logrotate_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-core/logrotate/logrotate_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+    file://xen \
+    file://messages \
+"
+
+FILES_${PN} += " \
+    ${sysconfdir}/logrotate.d/* \
+"
+
+do_install_append () {
+    install -d 755 ${D}/${sysconfdir}/logrotate.d/
+
+    install -m 644 ${WORKDIR}/xen ${D}/${sysconfdir}/logrotate.d/
+    install -m 644 ${WORKDIR}/messages ${D}/${sysconfdir}/logrotate.d/
+}

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
@@ -1,6 +1,7 @@
 IMAGE_INSTALL_append = " \
     tzdata \
     aos-servicemanager \
+    logrotate \
     openssh-sshd \
     openssh-scp \
 "

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/logrotate/files/messages
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/logrotate/files/messages
@@ -1,0 +1,6 @@
+/var/log/messages {
+    size 8M
+    missingok
+    rotate 1
+    notifempty
+}

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/logrotate/logrotate_%.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/logrotate/logrotate_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+    file://messages \
+"
+
+FILES_${PN} += " \
+    ${sysconfdir}/logrotate.d/* \
+"
+
+do_install_append () {
+    install -d 755 ${D}/${sysconfdir}/logrotate.d/
+
+    install -m 644 ${WORKDIR}/messages ${D}/${sysconfdir}/logrotate.d/
+}


### PR DESCRIPTION
This patch enables logrotate and also adds configs to rotate /var/log/xen
and /var/log/messages logs.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>