### PR TITLE
domf: add nodejs to aos-servicemanager runtime dependencies

### DIFF
--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/aos-servicemanager_git.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/aos-servicemanager_git.bbappend
@@ -12,6 +12,10 @@ SRC_URI_append = " \
 
 inherit systemd
 
+RDEPENDS_${PN} += "\
+    nodejs \
+"
+
 SYSTEMD_SERVICE_${PN} = " \
     first-boot.service \
 "


### PR DESCRIPTION
In order to run nodejs services, we need to have nodejs installed on the
system.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>