### PR TITLE
Set fixed Linux kernel revision

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-BRANCH = "master"
-SRCREV = "${AUTOREV}"
+BRANCH = "rcar-3.7.0-xt.final"
+SRCREV = "7794f75ca7eba6cd6f19b80f8a45bc18fe3230d1"
 LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,7 +1,7 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
-BRANCH = "master"
-SRCREV = "${AUTOREV}"
+BRANCH = "rcar-3.7.0-xt.final"
+SRCREV = "7794f75ca7eba6cd6f19b80f8a45bc18fe3230d1"
 LINUX_VERSION = "4.14.35"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 SRC_URI_remove = " \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -4,8 +4,8 @@ require inc/xt_shared_env.inc
 
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
-BRANCH = "master"
-SRCREV = "${AUTOREV}"
+BRANCH = "rcar-3.7.0-xt.final"
+SRCREV = "7794f75ca7eba6cd6f19b80f8a45bc18fe3230d1"
 LINUX_VERSION = "4.14.35"
 SRC_URI_append = " \
     file://defconfig \

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -2,8 +2,8 @@ require inc/xt_shared_env.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-BRANCH = "master"
-SRCREV = "${AUTOREV}"
+BRANCH = "rcar-3.7.0-xt.final"
+SRCREV = "7794f75ca7eba6cd6f19b80f8a45bc18fe3230d1"
 LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \


### PR DESCRIPTION
Due to current master branch of the Linux kernel repo modified
in order to use BSP-v3.15.0 set fixed revision for prod-aos.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>