### PR TITLE
domd: make telemetry-emulator as RDEPENDS of aos-vis

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/inc/agl-image.inc
@@ -4,7 +4,6 @@ IMAGE_INSTALL_append = " \
     guest-addons-bridge-config \
     kmscube \
     aos-vis \
-    ${@bb.utils.contains('AOS_VIS_PLUGINS', 'telemetryemulatoradapter', 'telemetry-emulator', '', d)} \
     logrotate \
 "
 

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-aos/aos-vis/aos-vis_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-aos/aos-vis/aos-vis_git.bbappend
@@ -28,6 +28,10 @@ FILES_${PN} += " \
     /var/aos/vis/visconfig.json \
 "
 
+RDEPENDS_${PN} += "\
+    ${@bb.utils.contains('AOS_VIS_PLUGINS', 'telemetryemulatoradapter', 'telemetry-emulator', '', d)} \
+"
+
 do_install_append() {
     install -d ${D}/var/aos/vis
     install -d ${D}${systemd_system_unitdir}


### PR DESCRIPTION
Checking AOS_VIS_PLUGINS in core-image-weston.bbappend is not correct. As
this variable is not defined by default in local config. As result
telemetry-emulator is not installed by default regardless telemetry
emulator adapter is installed. The right solution is to add telemetry-
emulator as RDEPENDS in aos-vis recipe.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>
Reviewed-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>