### PR TITLE
dom0: Fix incorrect merge in conf files

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
@@ -33,10 +33,6 @@ dt_compatible = [ "renesas,h3ulcb", "renesas,r8a7795" ]
 # Clocks and regulators are needed and are in the device tree root,
 # but we do not want to copy all root nodes: handle these one by one
 dt_passthrough_nodes = [
-<<<<<<< HEAD
-    "/avs@e60a013c",
-=======
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "/gsx_opp_table0",
     "/gsx_opp_table1",
     "/gsx_opp_table2",
@@ -57,11 +53,7 @@ dt_passthrough_nodes = [
     "/firmware",
     "/soc",
     "/audio-clkout",
-<<<<<<< HEAD
-    "/avb-mch",
-=======
     "/avb-mch@ec5a0100",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "/hdmi0-out",
     "/keyboard",
     "/leds",
@@ -74,12 +66,9 @@ dt_passthrough_nodes = [
     "/x23-clock",
     "/vspm_if",
     "/versaclk-3",
-<<<<<<< HEAD
-=======
     "/versaclk-4",
     "/usb3s0",
     "/usb_extal",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 ]
 
 dtdev = [
@@ -205,11 +194,7 @@ irqs = [
     197,
 # sd@ee140000
     199,
-<<<<<<< HEAD
-# usb@ee0a0100
-=======
 # usb@ee0a0000
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     144,
 # imr-lx4@fe860000
     224,
@@ -309,11 +294,7 @@ iomem = [
 #sound@ec500000
     "ec500,1",
 #sound@ec500000
-<<<<<<< HEAD
-#avb-mch
-=======
 #avb-mch@ec5a0100
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "ec5a0,1",
 #sound@ec500000
     "ec540,1",
@@ -385,17 +366,6 @@ iomem = [
 #vspm@fe9b0000
     "fe9bf,1",
 #vsp@fea20000
-<<<<<<< HEAD
-    "fea20,4",
-#fcp@fea27000
-    "fea27,1",
-#vsp@fea28000
-    "fea28,4",
-#fcp@fea2f000
-    "fea2f,1",
-#vsp@fea30000
-    "fea30,4",
-=======
     "fea20,5",
 #fcp@fea27000
     "fea27,1",
@@ -405,7 +375,6 @@ iomem = [
     "fea2f,1",
 #vsp@fea30000
     "fea30,5",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 #fcp@fea37000
     "fea37,1",
 #fdpm@fe940000
@@ -420,11 +389,6 @@ iomem = [
     "fead0,10",
 #display@feb00000
     "feb00,80",
-<<<<<<< HEAD
-#display@feb00000
-    "feb90,1",
-=======
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 #thermal@e6198000
     "e6198,1",
 #thermal@e6198000

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-m3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-m3ulcb.cfg
@@ -33,10 +33,6 @@ dt_compatible = [ "renesas,m3ulcb", "renesas,r8a7796" ]
 # Clocks and regulators are needed and are in the device tree root,
 # but we do not want to copy all root nodes: handle these one by one
 dt_passthrough_nodes = [
-<<<<<<< HEAD
-    "/avs@e60a013c",
-=======
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "/gsx_opp_table0",
     "/gsx_opp_table1",
     "/gsx_opp_table2",
@@ -57,11 +53,7 @@ dt_passthrough_nodes = [
     "/firmware",
     "/soc",
     "/audio-clkout",
-<<<<<<< HEAD
-    "/avb-mch",
-=======
     "/avb-mch@ec5a0100",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "/hdmi0-out",
     "/keyboard",
     "/leds",
@@ -74,11 +66,8 @@ dt_passthrough_nodes = [
     "/x23-clock",
     "/vspm_if",
     "/versaclk-3",
-<<<<<<< HEAD
-=======
     "/usb3s0",
     "/usb_extal",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 ]
 
 dtdev = [
@@ -301,11 +290,7 @@ iomem = [
 #sound@ec500000
     "ec500,1",
 #sound@ec500000
-<<<<<<< HEAD
-#avb-mch
-=======
 #avb-mch@ec5a0100
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
     "ec5a0,1",
 #sound@ec500000
     "ec540,1",
@@ -349,17 +334,6 @@ iomem = [
 #vspm@fe9a0000
     "fe9af,1",
 #vsp@fea20000
-<<<<<<< HEAD
-    "fea20,4",
-#fcp@fea27000
-    "fea27,1",
-#vsp@fea28000
-    "fea28,4",
-#fcp@fea2f000
-    "fea2f,1",
-#vsp@fea30000
-    "fea30,4",
-=======
     "fea20,5",
 #fcp@fea27000
     "fea27,1",
@@ -369,18 +343,12 @@ iomem = [
     "fea2f,1",
 #vsp@fea30000
     "fea30,5",
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 #fcp@fea37000
     "fea37,1",
 #hdmi@fead0000
     "fead0,10",
 #display@feb00000
     "feb00,70",
-<<<<<<< HEAD
-#display@feb00000
-    "feb90,1",
-=======
->>>>>>> 3f0fd2a... dom0: Update domain configs for all supported machines
 #imr-lx4@fe860000
     "fe860,2",
 #imr-lx4@fe870000


### PR DESCRIPTION
h3ulcb and m3ulcb config files were incorrect merged
during migration to Yocto-thud so fix it.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>