### PR TITLE
Set fixed revs for libxenbe/snd_be/displ_be

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "b5d07a43ba56380f2da8f47d7d106afbde0f2a3e"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=master"
 

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/libxenbe/libxenbe_git.bbappend
@@ -1,6 +1,6 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "683e65ebc2e4738466cb0437460ba7c61afe2f92"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/libxenbe.git;protocol=https;branch=master"

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/sndbe/sndbe_git.bbappend
@@ -1,7 +1,7 @@
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRCREV_rcar = "${AUTOREV}"
+SRCREV_rcar = "f25453f6dd63652958227652d20a01b7627ca141"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/snd_be.git;protocol=https;branch=master"
 


### PR DESCRIPTION
The master branches for these components are about to be updated
to support Xen v4.13 release. In order not to break this product,
which is still using Xen v4.12, set fixed revs for the components
in questions.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>