### PR TITLE
domd: WORKAROUND: Set fixed MAC address for eth0 on cetibox

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/sja1105-tool/sja1105-tool/eth_full_reset.sh
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/sja1105-tool/sja1105-tool/eth_full_reset.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 GPIO_PATH=/sys/class/gpio
 
+ifconfig eth0 hw ether 02:01:02:03:04:08
+
 # interface must be up for phytool to access PHYs
 ip link set dev eth0 up
 


### PR DESCRIPTION
This is actually rather a workaround than a fix and
needs better understanding of why MAC address does not
persist.

Signed-off-by: Viktor Mitin <viktor_mitin@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>