### PR TITLE
Align asound.state with prod-devel

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-bsp/alsa-state/files/kingfisher/asound.state
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-bsp/alsa-state/files/kingfisher/asound.state
@@ -1,4 +1,4 @@
-state.rcarsound {
+state.ak4613 {
 	control.1 {
 		iface MIXER
 		name 'Digital Playback Volume1'


### PR DESCRIPTION
This is patch contains two changes from prod-devel:
https://github.com/xen-troops/meta-xt-prod-devel/pull/204
https://github.com/xen-troops/meta-xt-prod-devel/pull/208/

Summary of changes:
- Remove obsolete part 'rsnddai0ak4613h'
- Rename 'rcar-sound' to 'rcarsound'
- Use dedicated asound.state for SK+KF

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>