### PR TITLE
domd: Use eth0.network from systemd recipe

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/eth0.network
@@ -1,6 +1,0 @@
-[Match]
-Name=eth0
-KernelCommandLine=!nfsroot
-
-[Network]
-DHCP=yes

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -14,7 +14,6 @@ SRC_URI = " \
     file://dm-salvator-x-m3.cfg \
     file://dm-salvator-x-h3.cfg \
     file://dm-ulcb.cfg \
-    file://eth0.network \
     file://xenbr0.netdev \
     file://xenbr0.network \
     file://xenbr0-systemd-networkd.conf \
@@ -33,7 +32,6 @@ PACKAGES += " \
 "
 
 FILES_${PN}-bridge-config = " \
-    ${sysconfdir}/systemd/network/eth0.network \
     ${sysconfdir}/systemd/network/xenbr0.netdev \
     ${sysconfdir}/systemd/network/xenbr0.network \
     ${sysconfdir}/systemd/system/systemd-networkd.service.d/xenbr0-systemd-networkd.conf \


### PR DESCRIPTION
Both systemd and guest addons try to install the same eth0.network.
Fix this by using the one provided by systemd.

Fixes: 8f96b8a6ef14 ("domd: Configure ethernet switch ports and VLANs")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>