### PR TITLE
domd: update setting of dnsmasq

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
@@ -14,7 +14,7 @@ do_install_append() {
 
     # Define DHCP leases range. Upper part of subnet can be used
     # for static configuration.
-    echo "dhcp-range=192.168.0.2,192.168.0.150,12h" >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "dhcp-range=xenbr0,192.168.0.2,192.168.0.150,12h" >> ${D}${sysconfdir}/dnsmasq.conf
 
     # Configure addresses for DomF and DomA. Mac addresses
     # are the same as in /xt/conf/*.conf
@@ -27,4 +27,20 @@ do_install_append() {
     # Add actual dependencies
     install -d ${D}${sysconfdir}/systemd/system/dnsmasq.service.d
     install -m 0644 ${WORKDIR}/depend.conf ${D}${sysconfdir}/systemd/system/dnsmasq.service.d/
+}
+
+do_install_append_cetibox() {
+    # Cetibox has two physical eth connectors: uplink (eth0.1) and downlink (eth0.2)
+    # device on downlink expects DHCP from us, so we have to set
+    # dnsmasq accordingly
+    echo "interface=eth0.2" >> ${D}${sysconfdir}/dnsmasq.conf
+
+    # Define DHCP leases range. Upper part of subnet can be used
+    # for static configuration.
+    echo "dhcp-range=eth0.2,10.0.0.100,10.0.0.110,12h" >> ${D}${sysconfdir}/dnsmasq.conf
+
+    echo "# Assign 10.0.0.100 to connected device for proper work of updater." >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "# Temporary hack. Need to be removed after proper fix." >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "# Uncomment following line and edit MAC of your device" >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "# dhcp-host=2e:09:0a:00:a0:41,10.0.0.100,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
 }

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/eth0.2.network
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/eth0.2.network
@@ -3,11 +3,4 @@ Name=eth0.2
 
 [Network]
 Address=10.0.0.1/24
-DHCPServer=yes
 IPMasquerade=yes
-
-[DHCPServer]
-PoolOffset=100
-PoolSize=1
-EmitDNS=yes
-#DNS=10.17.110.5


### PR DESCRIPTION
Dnsmasq is used as DHCP server not only for inter-domain network
but for connected devices as well.

Suggested-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>