### PR TITLE
domu-image-fusion: Enable haveged to provide more entropy

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -16,6 +16,7 @@ IMAGE_INSTALL_append = " \
     expect \
     openssh-scp \
     openssh-ssh \
+    haveged \
 "
 
 XT_GUESTS_INSTALL ?= "doma domf"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
@@ -5,6 +5,7 @@ IMAGE_INSTALL_append = " \
     logrotate \
     openssh-sshd \
     openssh-scp \
+    haveged \
 "
 
 populate_vmlinux () {


### PR DESCRIPTION
The lack of the entropy prevents openssl to work correctly.
Enable haveged package provided by meta-openembedded layer in order
to ensure that openssl has sufficient entropy during boot time.

Haveged is used to generate random numbers and feed the Linux
random device. Haveged seems to be a good solution in providing
more entropy for hardwareless domains.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>