### PR TITLE
domd cetibox: remove eth0.network from guest-addons

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -23,6 +23,8 @@ SRC_URI = " \
     file://systemd-networkd-wait-online.conf \
 "
 
+SRC_URI_remove_cetibox = "file://eth0.network"
+
 S = "${WORKDIR}"
 
 inherit systemd
@@ -40,6 +42,7 @@ FILES_${PN}-bridge-config = " \
     ${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf \
     ${sysconfdir}/systemd/system/systemd-networkd-wait-online.service.d/systemd-networkd-wait-online.conf \
 "
+FILES_${PN}-bridge-config_remove_cetibox = "${sysconfdir}/systemd/network/eth0.network"
 
 SYSTEMD_PACKAGES = " \
     ${PN}-bridge-up-notification-service \


### PR DESCRIPTION
2 recipes deploy the same file , what is the cause of the following errors
Collected errors:

    check_data_file_clashes: Package systemd wants to install file /home/iusyk/xen/epam/build-workspace/build/tmp/work/x86_64-xt-linux/domd-image-minimal/1.0-r0/repo/build/tmp/work/h3ulcb_cb_xt-poky-linux/core-image-minimal/1.0-r0/rootfs/etc/systemd/network/eth0.network
    But that file is already provided by package * guest-addons-bridge-config

ERROR: Unable to install packages. Command '/mnt/work/build/build/tmp/work/x86_64-xt-linux/domd-image-minimal/1.0-r0/repo/build/tmp/work/h3ulcb_cb_xt-poky-linux/core-image-minimal/1.0-r0/recipe-sysroot-native/usr/bin/opkg --volatile-cache -f /mnt/work/build/build/tmp/work/x86_64-xt-linux/domd-image-minimal/1.0-r0/repo/build/tmp/work/h3ulcb_cb_xt-poky-linux/core-image-minimal/1.0-r0/opkg.conf -t /mnt/work/build/build/tmp/work/x86_64-xt-linux/domd-image-minimal/1.0-r0/repo/build/tmp/work/h3ulcb_cb_xt-poky-linux/core-image-minimal/1.0-r0/temp/ipktemp/ -o /mnt/work/build/build/tmp/work/x86_64-xt-linux/domd-image-minimal/1.0-r0/repo/build/tmp/work/h3ulcb_cb_xt-poky-linux/core-image-minimal/1.0-r0/rootfs --force_postinstall --prefer-arch-to-version install aos-vis bash coreutils devmem2 i2c-tools kernel-module-qos kernel-modules libqos1 libxenbe nftables optee-os packagegroup-core-boot packagegroup-xt-core-guest-addons packagegroup-xt-core-network packagegroup-xt-core-xen phytool qosif-tp-user-module run-postinsts sja1105-tool v4l-utils xen-base xen-flask xen-xenstat' returned 255:
"

to avoid it , the deployment eth0.network is rempved from guest-addons recipe