### PR TITLE
cetibox aos: domd support of python

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-minimal
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-minimal
@@ -17,6 +17,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
+  ${TOPDIR}/../meta-python \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \


### PR DESCRIPTION
during the ces2020 integration was found that pythin has to be deployed for domd