### PR TITLE
cetibox aos: domd support of python

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-minimal
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-minimal
@@ -17,6 +17,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
+  ${TOPDIR}/../meta-python \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/images/core-image-minimal.bbappend
@@ -5,6 +5,16 @@ IMAGE_INSTALL_append = " \
     kernel-modules \
     optee-os \
     libxenbe \
+    python3 \
+    python3-compression \
+    python3-core \
+    python3-crypt \
+    python3-json \
+    python3-misc \
+    python3-shell \
+    python3-six \
+    python3-threading \
+    python3-websocket-client \
 "
 
 python __anonymous () {


### PR DESCRIPTION
during the ces2020 integration was found that pythin has to be deployed for domd