### PR TITLE
CES 2020: support of provisioning

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -16,6 +16,7 @@ IMAGE_INSTALL_append = " \
     expect \
     openssh-scp \
     openssh-ssh \
+    provisioning \
 "
 
 XT_GUESTS_INSTALL ?= "doma domf"


### PR DESCRIPTION
CES 2020: support of provisioning
    
During the integration it has been found that this feature is required
The commit removes the binding to the board 'cetibox',
because this is the prod-aos feature, not board one