### PR TITLE
Revert "Cb provisioning"

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -19,10 +19,6 @@ IMAGE_INSTALL_append = " \
     haveged \
 "
 
-IMAGE_INSTALL_append_cetibox = "\
-    provisioning \
-"
-
 XT_GUESTS_INSTALL ?= "doma domf"
 
 python __anonymous () {


### PR DESCRIPTION
Reverts xen-troops/meta-xt-prod-aos#69

Reverted because provisioning is not board feature
This is product one, the corresponded change:
https://github.com/xen-troops/meta-xt-prod-aos/pull/70