### PR TITLE
dom0: provisioning: Create model_name.txt

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
@@ -20,4 +20,7 @@ do_install() {
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}
     install -m 0755 ${S}/aos-provisioning.step1.sh ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}
     install -m 0755 ${S}/aos-provisioning.step2.sh ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}
+
+    install -d ${sysconfdir}/aos
+    echo ${XT_CANONICAL_MACHINE_NAME} > ${sysconfdir}/aos/model_name.txt
 }


### PR DESCRIPTION
For provisioning purposes we need to have /etc/aos/model_name.txt
file with some info that allows to distinct 'device family'.
This path uses XT_CANONICAL_MACHINE_NAME as model name.
See meta-xt-images/machine/meta-xt-images-rcar-gen3/conf/machine/*
for possible values of machine(model) name.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>