### PR TITLE
dom0: provisioning: Fix2 for model_name.txt

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 FILES_${PN} = " \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/aos-provisioning.step1.sh \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/aos-provisioning.step2.sh \
+    ${sysconfdir}/aos/model_name.txt \
 "
 
 RDEPENDS_${PN} = "bash"


### PR DESCRIPTION
Additional fix for
ca44c06 ("dom0: provisioning: Fix path to model_name.txt")
which in it's turn is fix for
788283d ("dom0: provisioning: Create model_name.txt")

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>