### PR TITLE
domd: dnsmasq: Assign 10.0.0.100 to device on eth0.2

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
@@ -35,12 +35,16 @@ do_install_append_cetibox() {
     # dnsmasq accordingly
     echo "interface=eth0.2" >> ${D}${sysconfdir}/dnsmasq.conf
 
-    # Define DHCP leases range. Upper part of subnet can be used
-    # for static configuration.
-    echo "dhcp-range=eth0.2,10.0.0.100,10.0.0.110,12h" >> ${D}${sysconfdir}/dnsmasq.conf
-
-    echo "# Assign 10.0.0.100 to connected device for proper work of updater." >> ${D}${sysconfdir}/dnsmasq.conf
-    echo "# Temporary hack. Need to be removed after proper fix." >> ${D}${sysconfdir}/dnsmasq.conf
-    echo "# Uncomment following line and edit MAC of your device" >> ${D}${sysconfdir}/dnsmasq.conf
-    echo "# dhcp-host=2e:09:0a:00:a0:41,10.0.0.100,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    # We use special configuration for CB:
+    # - only one device is connected to eth0.2
+    # - this connected device must have IP 10.0.0.100
+    # - connected device can be replaced (we can't hardcode MAC)
+    # For now best solution is to assign 10.0.0.100 to anything
+    # that is connected to eth0.2.
+    # To do this we
+    # 1) assign pool of 1 IP
+    # 2) prevent dnsmasq from storing leases across reboot using /var/run as storage
+    #    this results in reassignment of addresses on each reboot of CB.
+    echo "dhcp-range=eth0.2,10.0.0.100,10.0.0.100,12h" >> ${D}${sysconfdir}/dnsmasq.conf
+    echo "dhcp-leasefile=/var/run/dnsmasq.leases" >> ${D}${sysconfdir}/dnsmasq.conf
 }


### PR DESCRIPTION
We use special configuration for CB:
  - only one device is connected to eth0.2
  - this connected device must have IP 10.0.0.100
  - connected device can be replaced (we can't hardcode MAC)

For now best solution is to assign 10.0.0.100 to anything
that is connected to eth0.2.
To do this we
  1) assign pool of 1 IP
  2) prevent dnsmasq from storing leases across reboot
     using /var/run as storage this results in reassignment
     of addresses on each reboot of CB.

Suggested-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>