### PR TITLE
domd: network: Fix port forwarding for cetibox

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/cetibox/port-forward-systemd-networkd.conf
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/cetibox/port-forward-systemd-networkd.conf
@@ -1,0 +1,5 @@
+[Service]
+# ssh to domF
+ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0.1 -p tcp --dport 2022 -j DNAT --to-destination 192.168.0.3:22
+# adb to domA
+ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0.1 -p tcp --dport 5555 -j DNAT --to-destination 192.168.0.4:5555


### PR DESCRIPTION
On cetibox we have eth0.1 instead of eth0, so appropriate changes
are required for correct inter-domain port forwarding.

Suggested-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>