### PR TITLE
aos fixing

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/dom0.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/dom0.bb
@@ -23,6 +23,7 @@ DOM0_ALLOWED_PCPUS_salvator-xs-h3-4x2g-xt = "4-7"
 DOM0_ALLOWED_PCPUS_h3ulcb-4x2g-xt = "4-7"
 DOM0_ALLOWED_PCPUS_h3ulcb-4x2g-kf-xt = "4-7"
 DOM0_ALLOWED_PCPUS_h3ulcb-cb-xt = "4-7"
+DOM0_ALLOWED_PCPUS_h3ulcb-xt = "4-7"
 
 FILES_${PN} = " \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}/start_guest.sh \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domd.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domd.bb
@@ -16,6 +16,7 @@ SRC_URI = "\
     file://domd-h3ulcb-4x2g.cfg \
     file://domd-h3ulcb-4x2g-kf.cfg \
     file://domd-h3ulcb-cb.cfg \
+    file://domd-h3ulcb.cfg \
     file://guest_domd \
 "
 
@@ -29,6 +30,7 @@ DOMD_CONFIG_salvator-x-h3-4x2g-xt = "domd-salvator-x-h3-4x2g.cfg"
 DOMD_CONFIG_h3ulcb-4x2g-xt = "domd-h3ulcb-4x2g.cfg"
 DOMD_CONFIG_h3ulcb-4x2g-kf-xt = "domd-h3ulcb-4x2g-kf.cfg"
 DOMD_CONFIG_h3ulcb-cb-xt = "domd-h3ulcb-cb.cfg"
+DOMD_CONFIG_h3ulcb-xt = "domd-h3ulcb.cfg"
 
 FILES_${PN} = " \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domd.cfg \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domf.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domf.bb
@@ -21,6 +21,7 @@ DOMF_ALLOWED_PCPUS_salvator-x-h3-4x2g-xt = "4-7"
 DOMF_ALLOWED_PCPUS_h3ulcb-4x2g-xt = "4-7"
 DOMF_ALLOWED_PCPUS_h3ulcb-4x2g-kf-xt = "4-7"
 DOMF_ALLOWED_PCPUS_h3ulcb-cb-xt = "4-7"
+DOMF_ALLOWED_PCPUS_h3ulcb-xt = "4-7"
 
 FILES_${PN} = " \
     ${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domf.cfg \

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-aos/aos-vis/aos-vis_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-aos/aos-vis/aos-vis_git.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRCREV = "1bb72348b33013b2e6dba9ac3e20ce812085322d"
+
 SRC_URI_append = "\
     file://aos-vis.service \
     file://visconfig.json \

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -130,6 +130,21 @@ KERNEL_DEVICETREE_h3ulcb-4x2g-xt = " \
 "
 
 ##############################################################################
+# H3ULCB ES3.0 4G
+###############################################################################
+# N.B. DomU device tree is reused from Salvator-X H3 ES3.0 4G
+###############################################################################
+SRC_URI_append_h3ulcb-xt = " \
+    file://r8a7795-h3ulcb-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
+    file://r8a7795-h3ulcb-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
+"
+
+KERNEL_DEVICETREE_h3ulcb-xt = " \
+    renesas/r8a7795-h3ulcb-dom0.dtb \
+    renesas/r8a7795-h3ulcb-domd.dtb \
+"
+
+##############################################################################
 # H3ULCB ES3.0 4x2G KF
 ###############################################################################
 # N.B. DomU device tree is reused from Salvator-X H3 ES3.0 4x2G

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/aos-servicemanager_git.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-servicemanager/aos-servicemanager_git.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRCREV = "49444fb111a1576a90f2f72f1f41b4b9066957b2"
+
 SRC_URI_append = " \
     file://aos_servicemanager.cfg \
     file://aos-servicemanager.service \

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-aos/aos-updatemanager/aos-updatemanager_git.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRCREV = "92ffa9d1411929bb25da30e01a6083ad162c5f88"
+
 SRC_URI_append = "\
     file://aos-updatemanager.service \
     file://aos_updatemanager.cfg \


### PR DESCRIPTION
Fix version and support of h3ulcb

The version of the following components have been fixed
aos-updatemanager
aos-vis
aos0servicemanager

The corresponded device tree files (dom0, domd)  and config file have been added to support
the h3ulcb.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>