### PR TITLE
Fix the versions for aug-2020-release

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -16,7 +16,7 @@ python __anonymous () {
 ################################################################################
 # Generic ARMv8
 ################################################################################
-SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_aos/dom0.xml;scmdata=keep"
+SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=aug-2020-release;manifest=prod_aos/dom0.xml;scmdata=keep"
 
 ###############################################################################
 # extra layers and files to be put after Yocto's do_unpack into inner builder

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/provisioning/provisioning.bb
@@ -4,7 +4,7 @@ require inc/xt_shared_env.inc
 
 LICENSE = "CLOSED"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "ef6868166b594ad073a8c988ded577a4ee9f9589"
 SRC_URI = "git://git@gitpct.epam.com/epmd-aepr/aos_sdk.git;protocol=ssh"
 
 S = "${WORKDIR}/git"

--- a/recipes-domd/domd-image-minimal/domd-image-minimal.bbappend
+++ b/recipes-domd/domd-image-minimal/domd-image-minimal.bbappend
@@ -13,7 +13,7 @@ python __anonymous () {
 }
 
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=aug-2020-release;manifest=${XT_MANIFEST_FOLDER}/domd.xml;scmdata=keep \
 "
 
 XT_QUIRK_UNPACK_SRC_URI += " \

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-extended/displaymanager/displaymanager_git.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "868e703b7652c9a40ae878d7d517f97398b4549c"
 
 SRC_URI_append = " \
     git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=master \

--- a/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
+++ b/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
@@ -18,7 +18,7 @@ XT_QUIRK_BB_ADD_LAYER_append = " \
 # Generic ARMv8
 ################################################################################
 SRC_URI += " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_aos/domf.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=aug-2020-release;manifest=prod_aos/domf.xml;scmdata=keep \
 "
 
 SRCREV_metago = "${AUTOREV}"


### PR DESCRIPTION
Scope
-The manifests dom0.xml, domf.xml, domd.xml are reffered at branch aug-2020-release
-The versions of gitpct.epam.com/epmd-aepr/aos_sdk and github.com/xen-troops/DisplayManager have been fixed

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>