### PR TITLE
u-boot-env.txt: Add missed env to support A/B slot approach by u-boot

### DIFF
--- a/doc/u-boot-env.txt
+++ b/doc/u-boot-env.txt
@@ -122,6 +122,9 @@ If no uEnv.txt was found, it should be created with the default configuration.
 
 To read uEnv.txt files on boot, the following configuration should be applied:
 
+setenv loadaddr 0x58000000
+setenv bootcmd_mmc0 'run mmc0_xen_load; run mmc0_dtb_load; run mmc0_kernel_load; run mmc0_xenpolicy_load; run mmc0_initramfs_load; bootm 0x48080000 0x74000000 0x48000000'
+
 setenv mmc0_dtb_load 'ext2load mmc 0:${aos_boot_slot} 0x48000000 /boot/dom0.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device mmcblk1'
 setenv mmc0_initramfs_load 'ext2load mmc 0:${aos_boot_slot} 0x74000000 /boot/uInitramfs'
 setenv mmc0_kernel_load 'ext2load mmc 0:${aos_boot_slot} 0x7a000000 /boot/Image'
@@ -131,9 +134,8 @@ setenv aos_slot1 1
 setenv aos_slot2 2
 
 setenv aos_default_vars 'setenv aos_boot_main 0; setenv aos_boot1_ok 1; setenv aos_boot2_ok 1; setenv aos_boot_part 0'
-setenv aos_save_vars 'env export -t ${loadaddr} aos_boot_main aos_boot_part aos_boot1_ok aos_boot2_ok; fatwrite mmc 0:3 ${loadaddr} /uEnv.txt ${filesize}'
-setenv aos_read_vars 'if load mmc 0:3 ${loadaddr} /uEnv.txt; then env import -t ${loadaddr} ${filesize}; else run aos_default_vars; run aos_save_vars; fi'
-
+setenv aos_save_vars 'env export -t ${loadaddr} aos_boot_main aos_boot_part aos_boot1_ok aos_boot2_ok; fatwrite mmc 0:3 ${loadaddr} uEnv.txt ${filesize}'
+setenv aos_read_vars 'if load mmc 0:3 ${loadaddr} uEnv.txt; then env import -t ${loadaddr} ${filesize}; else run aos_default_vars; run aos_save_vars; fi'
 
 setenv aos_boot1 'if test ${aos_boot1_ok} -eq 1; then setenv aos_boot1_ok 0; setenv aos_boot2_ok 1; setenv aos_boot_part 0; setenv aos_boot_slot ${aos_slot1}; run aos_save_vars; run bootcmd_mmc0; fi'
 setenv aos_boot2 'if test ${aos_boot2_ok} -eq 1; then setenv aos_boot2_ok 0; setenv aos_boot1_ok 1; setenv aos_boot_part 1; setenv aos_boot_slot ${aos_slot2}; run aos_save_vars; run bootcmd_mmc0; fi'


### PR DESCRIPTION
Fixes: 941bba0 ("u-boot-env.txt: Documented usage of A/B slot approach by u-boot")
Signed-off-by: Yevgen Abramov <Yevgen_Abramov@epam.com>
Reviewed-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>