### PR TITLE
[u-boot-env] Set default aos values before loading them from file

### DIFF
--- a/doc/u-boot-env.txt
+++ b/doc/u-boot-env.txt
@@ -135,7 +135,7 @@ setenv aos_slot2 2
 
 setenv aos_default_vars 'setenv aos_boot_main 0; setenv aos_boot1_ok 1; setenv aos_boot2_ok 1; setenv aos_boot_part 0'
 setenv aos_save_vars 'env export -t ${loadaddr} aos_boot_main aos_boot_part aos_boot1_ok aos_boot2_ok; fatwrite mmc 0:3 ${loadaddr} uEnv.txt ${filesize}'
-setenv aos_read_vars 'if load mmc 0:3 ${loadaddr} uEnv.txt; then env import -t ${loadaddr} ${filesize}; else run aos_default_vars; run aos_save_vars; fi'
+setenv aos_read_vars 'run aos_default_vars; if load mmc 0:3 ${loadaddr} uEnv.txt; then env import -t ${loadaddr} ${filesize}; else run aos_save_vars; fi'
 
 setenv aos_boot1 'if test ${aos_boot1_ok} -eq 1; then setenv aos_boot1_ok 0; setenv aos_boot2_ok 1; setenv aos_boot_part 0; setenv aos_boot_slot ${aos_slot1}; run aos_save_vars; run bootcmd_mmc0; fi'
 setenv aos_boot2 'if test ${aos_boot2_ok} -eq 1; then setenv aos_boot2_ok 0; setenv aos_boot1_ok 1; setenv aos_boot_part 1; setenv aos_boot_slot ${aos_slot2}; run aos_save_vars; run bootcmd_mmc0; fi'


### PR DESCRIPTION
If file is corrupted or empty, we should have default values for missing
vars.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>