### PR TITLE
[cetibox] Enable IPMasquerade on eth0.1 interface

### DIFF
--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/cetibox/eth0.1.network
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/cetibox/eth0.1.network
@@ -3,4 +3,4 @@ Name=eth0.1
 
 [Network]
 DHCP=yes
-IPMasquerade=yes
+IPMasquerade=ipv4

--- a/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/cetibox/eth0.2.network
+++ b/recipes-domd/domd-image-minimal/files/meta-xt-prod-extra/recipes-core/systemd/files/cetibox/eth0.2.network
@@ -3,4 +3,3 @@ Name=eth0.2
 
 [Network]
 Address=10.0.0.1/24
-IPMasquerade=yes


### PR DESCRIPTION
Beacuse any positive boolean values such as "yes" or "true" are now deprecated.
for IPMasquerade parameter. Value was changed to ipv4.

Signed-off-by: Yevgen Abramov <Yevgen_Abramov@epam.com>