### PR TITLE
[INSTALL.md] Fix list of required packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,12 +6,13 @@
 
 ```bash
    apt-get install gawk wget diffstat texinfo chrpath socat libsdl1.2-dev \
-                    python3-cryptography repo checkpolicy  bizone \
+                    python3-cryptography repo checkpolicy \
                     bzr pigz m4 lftp openjdk-8-jdk git-core \
                     gnupg flex bison gperf build-essential zip curl zlib1g-dev \
                     gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev \
                     x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev \
-                    libxml2-utils xsltproc unzip gcc-5 g++-5 -y
+                    libxml2-utils xsltproc unzip gcc-5 g++-5 ostree \
+                    -y
 
    pip3 install configparser pygithub  gitpython
 ```


### PR DESCRIPTION
Remove `bizone` as misspeled name of already mentioned package `bison`.
Add `ostree`.

This commit fixes issues:
https://github.com/xen-troops/meta-xt-prod-aos/issues/112 "ostree is not specified in dependencies"
https://github.com/xen-troops/meta-xt-prod-aos/issues/113 "Install.txt: packge bizone does not exist , use bison instead"